### PR TITLE
Fix "file_path_sans_ext"

### DIFF
--- a/R/file_path_sans_ext.R
+++ b/R/file_path_sans_ext.R
@@ -1,5 +1,5 @@
 file_path_sans_ext <- function(x,compression=FALSE) {
   if (compression)
     x <- sub("[.](gz|bz2|xz)$", "", x)
-  sub("([^.]+.+)\\.[[:alnum:]]+$", "\\1", x)
+  sub("(.+)\\.[[:alnum:]]+$", "\\1", x)
 }

--- a/pizzR.Rproj
+++ b/pizzR.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: 841baf4b-e295-4055-a4ea-73ac7f42cb9c
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
File paths with length < 2 included still file-extension. Fixed this to also work for paths with length = 1